### PR TITLE
RNG Reproducibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -571,6 +571,12 @@ Encoded with quality range of (10, 15)
 ![JPEG Compression Before](images/Augmentations/JPEGCompressionBefore.png)
 ![JPEG Compression After](images/Augmentations/JPEGCompression.png)
 
+# Reproducibility
+This library uses the Python standard library's [random](https://docs.python.org/3/library/random.html) module to generate pseudorandom numbers. If you want to limit nondeterministic results, consider setting the [random seed](https://docs.python.org/3/library/random.html#random.seed) in programs that use the Augraphy library, by including `random.seed(42)` in your scripts. (The number 42 is not required; feel free to choose your own memorable seed when requiring deterministic RNG).
+
+
+Depending on your application, you may also need to set the [numpy random seed](https://docs.scipy.org/doc/numpy-1.15.0/reference/generated/numpy.random.seed.html) or the seeds for other sources of randomness (for a brief overview, see [here](https://pytorch.org/docs/stable/notes/randomness.html)), but Augraphy does not depend on these for random number generation.
+
 # Contributing
 Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.
 

--- a/src/augraphy/augmentations/brightnesstexturize.py
+++ b/src/augraphy/augmentations/brightnesstexturize.py
@@ -45,9 +45,9 @@ class BrightnessTexturizeAugmentation(Augmentation):
 
             low = value - (value * self.deviation)  # *random.uniform(0, deviation)
             max = value + (value * self.deviation)
-            brightness_matrix = np.random.uniform(
-                low, max, (hsv.shape[0], hsv.shape[1])
-            )
+
+            makerand = np.vectorize(lambda x: random.uniform(low,max))
+            brightness_matrix = makerand(np.array((hsv.shape[0], hsv.shape[1])))
             hsv[:, :, 1] *= brightness_matrix
             hsv[:, :, 2] *= brightness_matrix
             hsv[:, :, 1][hsv[:, :, 1] > 255] = 255
@@ -59,9 +59,9 @@ class BrightnessTexturizeAugmentation(Augmentation):
 
             low = value - (value * self.deviation)
             max = value + (value * self.deviation)
-            brightness_matrix = np.random.uniform(
-                low, max, (hsv.shape[0], hsv.shape[1])
-            )
+
+            makerand = np.vectorize(lambda x: random.uniform(low,max))
+            brightness_matrix = makerand(np.array((hsv.shape[0], hsv.shape[1])))
             hsv[:, :, 1] *= brightness_matrix
             hsv[:, :, 2] *= brightness_matrix
             hsv[:, :, 1][hsv[:, :, 1] > 255] = 255

--- a/src/augraphy/augmentations/noisetexturize.py
+++ b/src/augraphy/augmentations/noisetexturize.py
@@ -75,7 +75,10 @@ class NoiseTexturizeAugmentation(Augmentation):
         if w == 0:
             w = 1
 
-        result = np.random.normal(mean, sigma, (w, h, 1))
+
+        gaussian = np.vectorize(lambda x: random.gauss(mean,sigma))
+        result = gaussian(np.array((w,h)))
+
         if ratio > 1:
             result = cv2.resize(
                 result, dsize=(width, height), interpolation=cv2.INTER_LINEAR

--- a/src/augraphy/base/oneof.py
+++ b/src/augraphy/base/oneof.py
@@ -1,4 +1,3 @@
-import numpy as np
 import random
 
 from augraphy.base.augmentation import Augmentation
@@ -24,13 +23,8 @@ class OneOf(Augmentation):
     def __call__(self, data, force=False):
         if self.augmentation_probabilities and (force or self.should_run()):
 
-            # Seed the random object.
-            random_state = np.random.RandomState(random.randint(0, 2 ** 32 - 1))
-
             # Randomly selects one Augmentation to apply.
-            augmentation = random_state.choice(
-                self.augmentations, p=self.augmentation_probabilities
-            )
+            augmentation = random.choice(self.augmentations)
 
             # Applies the selected Augmentation.
             augmentation(data, force=True)


### PR DESCRIPTION
As discussed in #9 , it will be useful for testing purposes to control the degree of nondeterminism in the library.

To accomplish that goal, this PR does the following:
1. Removes all dependencies on `numpy.random` and replaces them with equivalent uses of `random.random` from Python's stdlib.
2. Updates `README.md` to:
    1. note the library's dependency only on `random.random` for random number generation,
    2. provide information about how to set the random seed to control this, and
    3. include links to useful documentation.