### PR TITLE
Add Letterpress Augmentation, begin internal function library

### DIFF
--- a/src/augraphy/augmentations/brightnesstexturize.py
+++ b/src/augraphy/augmentations/brightnesstexturize.py
@@ -44,10 +44,10 @@ class BrightnessTexturizeAugmentation(Augmentation):
             hsv = np.array(hsv, dtype=np.float64)
 
             low = value - (value * self.deviation)  # *random.uniform(0, deviation)
-            max = value + (value * self.deviation)
+            high = value + (value * self.deviation)
 
-            makerand = np.vectorize(lambda x: random.uniform(low,max))
-            brightness_matrix = makerand(np.array((hsv.shape[0], hsv.shape[1])))
+            makerand = np.vectorize(lambda x: random.uniform(low,high))
+            brightness_matrix = makerand(np.empty((hsv.shape[0], hsv.shape[1])))
             hsv[:, :, 1] *= brightness_matrix
             hsv[:, :, 2] *= brightness_matrix
             hsv[:, :, 1][hsv[:, :, 1] > 255] = 255
@@ -58,10 +58,10 @@ class BrightnessTexturizeAugmentation(Augmentation):
             hsv = np.array(hsv, dtype=np.float64)
 
             low = value - (value * self.deviation)
-            max = value + (value * self.deviation)
+            high = value + (value * self.deviation)
 
-            makerand = np.vectorize(lambda x: random.uniform(low,max))
-            brightness_matrix = makerand(np.array((hsv.shape[0], hsv.shape[1])))
+            makerand = np.vectorize(lambda x: random.uniform(low,high))
+            brightness_matrix = makerand(np.empty((hsv.shape[0], hsv.shape[1])))
             hsv[:, :, 1] *= brightness_matrix
             hsv[:, :, 2] *= brightness_matrix
             hsv[:, :, 1][hsv[:, :, 1] > 255] = 255

--- a/src/augraphy/augmentations/dustyink.py
+++ b/src/augraphy/augmentations/dustyink.py
@@ -3,6 +3,7 @@ import random
 
 from augraphy.base.augmentation import Augmentation
 from augraphy.base.augmentationresult import AugmentationResult
+from augraphy.augmentations.lib import addNoise
 
 
 class DustyInkAugmentation(Augmentation):
@@ -17,9 +18,7 @@ class DustyInkAugmentation(Augmentation):
     :type p: float, optional
     """
 
-    def __init__(
-        self, intensity_range=(0.1, 0.2), color_range=(0, 224), p=0.5
-    ):
+    def __init__(self, intensity_range=(0.1, 0.2), color_range=(0, 224), p=0.5):
         """Constructor method"""
         super().__init__(p=p)
         self.intensity_range = intensity_range
@@ -33,13 +32,5 @@ class DustyInkAugmentation(Augmentation):
     def __call__(self, data, force=False):
         if force or self.should_run():
             img = data["ink"][-1].result
-            intensity = random.uniform(self.intensity_range[0], self.intensity_range[1])
-            add_noise_fn = (
-                lambda x: random.randint(self.color_range[0], self.color_range[1])
-                if (x == 0 and random.random() < intensity)
-                else x
-            )
-            add_noise = np.vectorize(add_noise_fn)
-            img = add_noise(img)
-
+            img = addNoise(img)
             data["ink"].append(AugmentationResult(self, img))

--- a/src/augraphy/augmentations/dustyink.py
+++ b/src/augraphy/augmentations/dustyink.py
@@ -32,5 +32,5 @@ class DustyInkAugmentation(Augmentation):
     def __call__(self, data, force=False):
         if force or self.should_run():
             img = data["ink"][-1].result
-            img = addNoise(img)
+            img = addNoise(img, self.intensity_range, self.color_range)
             data["ink"].append(AugmentationResult(self, img))

--- a/src/augraphy/augmentations/letterpress.py
+++ b/src/augraphy/augmentations/letterpress.py
@@ -70,4 +70,4 @@ class LetterpressAugmentation(Augmentation):
 
             image = addNoise(image)
 
-            data["ink"].append(AugmentationResult(self, img))
+            data["ink"].append(AugmentationResult(self, image))

--- a/src/augraphy/augmentations/letterpress.py
+++ b/src/augraphy/augmentations/letterpress.py
@@ -1,0 +1,71 @@
+from augraphy.base.augmentation import Augmentation
+from augraphy.base.augmentationresult import AugmentationResult
+from augraphy.augmentations.lib import applyBlob, addNoise
+
+
+class LetterpressAugmentation(Augmentation):
+    """Produces regions of ink mimicking the effect of ink pressed unevenly onto paper.
+
+    :param count_range: Pair of ints determining the range from which the number
+           of blobs to generate is sampled.
+    :type count_range: tuple, optional
+    :param size_range: Pair of ints determining the range from which the
+           diameter of a blob is sampled.
+    :type size_range: tuple, optional
+    :param points_range: Pair of ints determining the range from which the
+           number of points in a blob is sampled.
+    :type points_range: tuple, optional
+    :param std_range: Pair of ints determining the range from which the
+           standard deviation of the blob distribution is sampled.
+    :type std_range: tuple, optional
+    :param features_range: Pair of ints determining the range from which the
+           number of features in the blob is sampled.
+    :type features_range: tuple, optional
+    :param value_range: Pair of ints determining the range from which the
+           value of a point in the blob is sampled.
+    :type value_range: tuple, optional
+    :param p: The probability this Augmentation will be applied.
+    :type p: float, optional
+    """
+
+
+    def __init__(self,
+                 count_range=(5, 25),
+                 size_range=(10, 20),
+                 points_range=(5, 25),
+                 std_range=(10, 75),
+                 features_range=(15, 25),
+                 value_range=(180, 250),
+                 p=0.5
+    ):
+        """Constructor method"""
+        super().__init__(p=p)
+        self.count_range = count_range
+        self.size_range = size_range
+        self.points_range = points_range
+        self.std_range = std_range
+        self.features_range = features_range
+        self.value_range = value_range
+
+    def __repr__(self):
+        return f"LetterpressAugmentation(count_range={self.count_range}, size_range={self.size_range}, points_range={self.points_range}, std_range={self.std_range}, features_range={self.features_range}, value_range={self.value_range}, p={self.p})"
+
+
+    def __call__(self, data, force=False):
+        if force or self.should_run():
+            image = data["ink"][-1].result.copy()
+            count = random.randint(self.count_range[0], self.count_range[1])
+
+            for i in range(count):
+                image = applyBlob(
+                    image,
+                    self.size_range,
+                    self.points_range,
+                    self.std_range,
+                    self.features_range,
+                    self.value_range,
+                )
+
+            image = addNoise(image)
+
+            data["ink"].append(AugmentationResult(self, img))

--- a/src/augraphy/augmentations/letterpress.py
+++ b/src/augraphy/augmentations/letterpress.py
@@ -1,3 +1,5 @@
+import random
+
 from augraphy.base.augmentation import Augmentation
 from augraphy.base.augmentationresult import AugmentationResult
 from augraphy.augmentations.lib import applyBlob, addNoise

--- a/src/augraphy/augmentations/lib.py
+++ b/src/augraphy/augmentations/lib.py
@@ -1,0 +1,124 @@
+"""This module contains functions generally useful for building augmentations."""
+
+import numpy as np
+from sklearn.datasets import make_blobs
+import random
+
+def addNoise(image, intensity_range=(0.1, 0.2), color_range=(0, 224)):
+    """Applies random noise to the input image.
+
+    :param image: The image to noise.
+    :type image: numpy.array
+    :param intensity_range: Pair of bounds for intensity sample.
+    :type intensity_range: tuple, optional
+    :param color_range: Pair of bounds for 8-bit colors.
+    :type color_range: tuple, optional
+    """
+
+    intensity = random.uniform(intensity_range[0], intensity_range[1])
+    noise = (
+        lambda x: random.randint(color_range[0], color_range[1])
+        if (x == 0 and random.random() < intensity)
+        else x
+    )
+    add_noise = np.vectorize(noise)
+
+    return add_noise(image)
+
+
+def _create_blob(
+    size_range=(10, 20),
+    points_range=(5, 25),
+    std_range=(10, 75),
+    features_range=(15, 25),
+    value_range=(180, 250),
+):
+    """Generates a Gaussian noise blob for placement in an image.
+    To be used with _apply_blob()
+
+    :param size_range: Pair of ints determining the range from which the
+           diameter of a blob is sampled.
+    :type size_range: tuple, optional
+    :param points_range: Pair of ints determining the range from which the
+           number of points in a blob is sampled.
+    :type points_range: tuple, optional
+    :param std_range: Pair of ints determining the range from which the
+           standard deviation of the blob distribution is sampled.
+    :type std_range: tuple, optional
+    :param features_range: Pair of ints determining the range from which the
+           number of features in the blob is sampled.
+    :type features_range: tuple, optional
+    :param value_range: Pair of ints determining the range from which the
+           value of a point in the blob is sampled.
+    :type value_range: tuple, optional
+    """
+    size = random.randint(size_range[0], size_range[1])
+    std = random.randint(std_range[0], std_range[1]) / 100
+    points = random.randint(points_range[0], points_range[1])
+    features = random.randint(features_range[0], features_range[1])
+
+    X, y = make_blobs(
+        n_samples=points, cluster_std=[std], centers=[(0, 0)], n_features=features
+    )  # , random_state=1)
+    X *= size // 4
+    X += size // 2
+    X = [[int(item) for item in items] for items in X]
+    blob = np.full((size, size, 1), 0, dtype="uint8")
+
+    for point in X:
+        if (
+            point[0] < blob.shape[0]
+            and point[1] < blob.shape[1]
+            and point[0] > 0
+            and point[1] > 0
+        ):
+            value = random.randint(value_range[0], value_range[1])
+            blob[point[0], point[1]] = value
+
+    return blob
+
+
+def applyBlob(
+    image,
+    size_range=(10, 20),
+    points_range=(5, 25),
+    std_range=(10, 75),
+    features_range=(15, 25),
+    value_range=(180, 250),
+):
+    """Places a Gaussian blob at a random location in the image.
+
+    :param image: The image to place the blob in.
+    :type image: numpy.array
+    :param size_range: Pair of ints determining the range from which the
+           diameter of a blob is sampled.
+    :type size_range: tuple, optional
+    :param points_range: Pair of ints determining the range from which the
+           number of points in a blob is sampled.
+    :type points_range: tuple, optional
+    :param std_range: Pair of ints determining the range from which the
+           standard deviation of the blob distribution is sampled.
+    :type std_range: tuple, optional
+    :param features_range: Pair of ints determining the range from which the
+           number of features in the blob is sampled.
+    :type features_range: tuple, optional
+    :param value_range: Pair of ints determining the range from which the
+           value of a point in the blob is sampled.
+    :type value_range: tuple, optional
+    """
+    blob = _create_blob(
+        size_range, points_range, std_range, features_range, value_range
+    )
+
+    x_start = random.randint(0, image.shape[1] - blob.shape[1])
+    y_start = random.randint(0, image.shape[0] - blob.shape[0])
+    x_stop = x_start + blob.shape[1]
+    y_stop = y_start + blob.shape[0]
+
+    image_chunk = image[y_start:y_stop, x_start:x_stop]
+
+    apply_chunk = np.vectorize(lambda x, y: max(x, y))
+
+    image[y_start:y_stop, x_start:x_stop] = apply_chunk(image_chunk, blob[:, :, 0])
+
+    return image

--- a/src/augraphy/augmentations/lowinkblobs.py
+++ b/src/augraphy/augmentations/lowinkblobs.py
@@ -5,6 +5,7 @@ from sklearn.datasets import make_blobs
 
 from augraphy.base.augmentation import Augmentation
 from augraphy.base.augmentationresult import AugmentationResult
+from augraphy.augmentations.lib import applyBlob
 
 
 class LowInkBlobsAugmentation(Augmentation):
@@ -50,49 +51,10 @@ class LowInkBlobsAugmentation(Augmentation):
         self.std_range = std_range
         self.features_range = features_range
         self.value_range = value_range
-        apply = lambda x, y: x if x > y else y
-        self.apply = np.vectorize(apply)
 
     # Constructs a string representation of this Augmentation.
     def __repr__(self):
         return f"LowInkBlobsAugmentation(count_range={self.count_range}, size_range={self.size_range}, points_range={self.points_range}, std_range={self.std_range}, features_range={self.features_range}, value_range={self.value_range}, p={self.p})"
-
-    def create_blob(self):
-        """Generates a Gaussian blob to place in the image."""
-        size = random.randint(self.size_range[0], self.size_range[1])
-        std = random.randint(self.std_range[0], self.std_range[1]) / 100
-        points = random.randint(self.points_range[0], self.points_range[1])
-        features = random.randint(self.features_range[0], self.features_range[1])
-
-        X, y = make_blobs(
-            n_samples=points, cluster_std=[std], centers=[(0, 0)], n_features=features
-        )  # , random_state=1)
-        X *= size // 4
-        X += size // 2
-        X = [[int(item) for item in items] for items in X]
-        blob = np.full((size, size, 1), 0, dtype="uint8")
-
-        for point in X:
-            if (
-                point[0] < blob.shape[0]
-                and point[1] < blob.shape[1]
-                and point[0] > 0
-                and point[1] > 0
-            ):
-                value = random.randint(self.value_range[0], self.value_range[1])
-                blob[point[0], point[1]] = value
-
-        return blob
-
-    def apply_blob(self, mask):
-        """Places a Gaussian blob at a random location in the image."""
-        blob = self.create_blob()
-        x_start = random.randint(0, mask.shape[1] - blob.shape[1])
-        y_start = random.randint(0, mask.shape[0] - blob.shape[0])
-        x_stop = x_start + blob.shape[1]
-        y_stop = y_start + blob.shape[0]
-        mask_chunk = mask[y_start:y_stop, x_start:x_stop]
-        mask[y_start:y_stop, x_start:x_stop] = self.apply(mask_chunk, blob[:, :, 0])
 
     # Applies the Augmentation to input data.
     def __call__(self, data, force=False):
@@ -101,6 +63,13 @@ class LowInkBlobsAugmentation(Augmentation):
             count = random.randint(self.count_range[0], self.count_range[1])
 
             for i in range(count):
-                self.apply_blob(image)
+                applyBlob(
+                    image,
+                    size_range,
+                    points_range,
+                    std_range,
+                    features_range,
+                    value_range,
+                )
 
             data["ink"].append(AugmentationResult(self, image))

--- a/src/augraphy/augmentations/lowinkblobs.py
+++ b/src/augraphy/augmentations/lowinkblobs.py
@@ -65,11 +65,11 @@ class LowInkBlobsAugmentation(Augmentation):
             for i in range(count):
                 applyBlob(
                     image,
-                    size_range,
-                    points_range,
-                    std_range,
-                    features_range,
-                    value_range,
+                    self.size_range,
+                    self.points_range,
+                    self.std_range,
+                    self.features_range,
+                    self.value_range,
                 )
 
             data["ink"].append(AugmentationResult(self, image))

--- a/src/augraphy/augmentations/lowinkblobs.py
+++ b/src/augraphy/augmentations/lowinkblobs.py
@@ -63,7 +63,7 @@ class LowInkBlobsAugmentation(Augmentation):
             count = random.randint(self.count_range[0], self.count_range[1])
 
             for i in range(count):
-                applyBlob(
+                image = applyBlob(
                     image,
                     self.size_range,
                     self.points_range,


### PR DESCRIPTION
This PR addresses #11 , by doing the following:

1. Pulling the important logic out of the "Dusty Ink" and "Ink Blobs" augmentations into `augmentations/lib.py` that can be called from other augmentations as needed. Later, we can move the useful bits out of the other augmentations and into this, so augmentations get easier to write and their effects easier to combine.
2. Combining the behavior of "Dusty Ink" and "Ink Blobs" into a new "Letterpress" augmentation. I didn't delete "Dusty Ink" and "Ink Blobs" yet.

I ran the Letterpress augmentation in the ink phase of a pipeline which otherwise only contained PaperFactory, on `pdf417gen` barcodes like the default pipeline, and here's one of the results:
![crappified1](https://user-images.githubusercontent.com/74747193/125914381-0467dea0-8dc9-49e0-bbba-cdd6e2b6e688.jpg)
