### PR TITLE
Added patch for folding augmentation.

### DIFF
--- a/augraphy/augmentations/folding.py
+++ b/augraphy/augmentations/folding.py
@@ -188,19 +188,26 @@ class Folding(Augmentation):
     # Apply perspective transform 2 times and get single folding effect
     def apply_folding(self, img, ysize, xsize, gradient_width, gradient_height, fold_noise):
          
-        min_fold_x = int(gradient_width[0] * xsize)
-        max_fold_x = int(gradient_width[1] * xsize)
+        min_fold_x = min(np.ceil(gradient_width[0] * xsize),xsize).astype('int')
+        max_fold_x = min(np.ceil(gradient_width[1] * xsize),xsize).astype('int')
         fold_width_one_side = int(random.randint(min_fold_x, max_fold_x)/2)      # folding width from left to center of folding, or from right to center of folding
         fold_x = random.randint(fold_width_one_side+1, xsize-fold_width_one_side-1) # center of folding
         
-        fold_y_shift_min = int(gradient_height[0] * ysize)
-        fold_y_shift_max = int(gradient_height[1] * ysize)
+        fold_y_shift_min = min(np.ceil(gradient_height[0] * ysize),ysize).astype('int')
+        fold_y_shift_max = min(np.ceil(gradient_height[1] * ysize),ysize).astype('int')
         fold_y_shift = random.randint(fold_y_shift_min, fold_y_shift_max) # y distortion in folding (support positive y value for now)
         
-        img_fold_l = self.warp_fold_left_side(img, ysize, fold_noise, fold_x, fold_width_one_side, fold_y_shift)
-        img_fold_r = self.warp_fold_right_side(img_fold_l, ysize, fold_noise, fold_x, fold_width_one_side, fold_y_shift)
-
-        return img_fold_r
+        if (max_fold_x > min_fold_x) and (fold_y_shift !=0) :
+            img_fold_l = self.warp_fold_left_side(img, ysize, fold_noise, fold_x, fold_width_one_side, fold_y_shift)
+            img_fold_r = self.warp_fold_right_side(img_fold_l, ysize, fold_noise, fold_x, fold_width_one_side, fold_y_shift)
+            return img_fold_r
+        else:
+            if (max_fold_x > min_fold_x):
+                print("Folding augmentation is not applied, please increase gradient width or image size")
+            else:
+                print("Folding augmentation is not applied, please increase gradient height or image size")    
+            return img
+        
     
     # Applies the Augmentation to input data.
     def __call__(self, data, force=False):


### PR DESCRIPTION
Basically gradient width and height of folding is based on % of image width and height. If the image size is too small , the width or height range will be the same and causing those errors. We would need 4 unique points for the perspective transform. I added an `if` loop to show warning message and prevent further computation if there is no 4 unique points.