### PR TITLE
Add Python 3.10 CI support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
   main:
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
 
     runs-on: ubuntu-latest
     steps:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37, py38, py39, pre-commit
+envlist = py37, py38, py39, py310, pre-commit
 
 [testenv]
 # install dependencies in the virtualenv where commands will be executed


### PR DESCRIPTION
Make GitHub Actions also use a Python 3.10 environment, and make tox work in there too.