### PR TITLE
Add archetype pipelines, more tests, and make pipelines directly callable

### DIFF
--- a/augraphy/default/__init__.py
+++ b/augraphy/default/__init__.py
@@ -1,3 +1,25 @@
-from augraphy.default.pipeline import default_augraphy_pipeline
+from augraphy.default.aktives_und_passives_rauchen import aktives_und_passives_rauchen
+from augraphy.default.default_augraphy_pipeline import default_augraphy_pipeline
+from augraphy.default.diahann_carroll import diahann_carroll
+from augraphy.default.harley_davidson import harley_davidson
+from augraphy.default.heparin_testosterone_rats import heparin_testosterone_rats
+from augraphy.default.ira_jay_goldberg import ira_jay_goldberg
+from augraphy.default.let_us_have_facts import let_us_have_facts
+from augraphy.default.lorillard import lorillard
+from augraphy.default.marlboro_500 import marlboro_500
+from augraphy.default.philip_morris import philip_morris
+from augraphy.default.statesmans_manual import statesmans_manual
 
-__all__ = ["default_augraphy_pipeline"]
+__all__ = [
+    "aktives_und_passives_rauchen",
+    "default_augraphy_pipeline",
+    "diahann_carroll",
+    "harley_davidson",
+    "heparin_testosterone_rats",
+    "ira_jay_goldberg",
+    "let_us_have_facts",
+    "lorillard",
+    "marlboro_500",
+    "philip_morris",
+    "statesmans_manual",
+]

--- a/augraphy/default/aktives_und_passives_rauchen.py
+++ b/augraphy/default/aktives_und_passives_rauchen.py
@@ -1,0 +1,64 @@
+import random
+
+import cv2
+import numpy as np
+
+from augraphy import *
+
+
+def aktives_und_passives_rauchen(clean):
+    ink1 = [
+        Geometric(crop=(150, 0, -1, -1)),
+        BookBinding(
+            radius_range=(10, 10),
+            curve_intensity_range=(70, 70),
+            mirror=1,
+            mirror_range=(0.2, 0.2),
+        ),
+        Folding(
+            fold_x=50,
+            fold_deviation=(0, 0),
+            fold_count=1,
+            fold_noise=1,
+            gradient_width=(0.18, 0.18),
+            gradient_height=(0.02, 0.02),
+        ),
+        Geometric(crop=(100, 0, -1, 2100)),
+        Faxify(
+            monochrome=1,
+            monochrome_method="Otsu",
+        ),
+    ]
+
+    paper1 = []
+    post1 = []
+    pipeline1 = AugraphyPipeline(ink1, paper1, post1)
+
+    img_output1 = pipeline1.augment(clean)["output"]
+
+    img_blank = np.full((2500, 1900), fill_value=255).astype("uint8")
+    img_blank[:200, :1760] = 0
+
+    ink2 = [
+        BindingsAndFasteners(
+            foreground=img_output1,
+            overlay_types="darken",
+            ntimes=1,
+            nscales=(1, 1),
+            edge="left",
+            edge_offset=0,
+        ),
+        BadPhotoCopy(
+            noise_type=4,
+            noise_iteration=(4, 8),
+            noise_size=(1, 4),
+            noise_sparsity=(1, 1),
+            noise_concentration=(0.5, 0.8),
+        ),
+    ]
+
+    paper2 = []
+    post2 = []
+
+    pipeline2 = AugraphyPipeline(ink2, paper2, post2)
+    return pipeline2.augment(img_blank)["output"]

--- a/augraphy/default/default_augraphy_pipeline.py
+++ b/augraphy/default/default_augraphy_pipeline.py
@@ -8,7 +8,7 @@ import random
 from augraphy import *
 
 
-def default_augraphy_pipeline():
+def default_augraphy_pipeline(clean):
     ink_phase = AugmentationSequence(
         [
             Dithering(p=0.5),
@@ -61,4 +61,6 @@ def default_augraphy_pipeline():
         ],
     )
 
-    return AugraphyPipeline(ink_phase, paper_phase, post_phase)
+    pipeline = AugraphyPipeline(ink_phase, paper_phase, post_phase)
+
+    return pipeline.augment(clean)["output"]

--- a/augraphy/default/diahann_carroll.py
+++ b/augraphy/default/diahann_carroll.py
@@ -1,0 +1,124 @@
+import math
+import random
+import shutil
+
+import cv2
+import numpy as np
+
+from augraphy import *
+from augraphy.utilities.figsharedownloader import FigshareDownloader
+
+
+def diahann_carroll(clean):
+
+    fsdl = FigshareDownloader()
+    fsdl.download_file_by_id(33912011, "1-holes.jpg")
+    fsdl.download_file_by_id(33947567, "1-P-742.jpg")
+    holes = cv2.imread("figshare/1-holes.jpg")
+    p742 = cv2.imread("figshare/1-P-742.jpg")
+
+    # create text with 600
+    # create blank image
+    img_600 = np.full((90, clean.shape[1]), fill_value=255).astype("uint8")
+
+    # config for text
+    font = cv2.FONT_HERSHEY_SCRIPT_COMPLEX
+    location = (1550, 70)
+    fontScale = 2
+    fontColor = (0, 0, 0)
+    thickness = 2
+    lineType = 2
+
+    # draw text 600 into image
+    img_600 = cv2.putText(
+        img_600,
+        "600",
+        location,
+        font,
+        fontScale,
+        fontColor,
+        thickness,
+        lineType,
+    )
+
+    # create objects for rotation and letterpress effect
+    rotate_object = Geometric(rotate_range=(45, 45))
+    letterpress_object = Letterpress(
+        n_samples=(1000, 1000),
+        n_clusters=(1000, 1000),
+        std_range=(800, 800),
+        value_range=(255, 255),
+        value_threshold_range=(150, 150),
+        blur=0,
+    )
+
+    img_600 = letterpress_object(rotate_object(img_600))
+    img_600 = img_600[:180, :]
+    img_600 = cv2.resize(img_600, (clean.shape[1], 180), interpolation=cv2.INTER_AREA)
+
+    # defining the pipeline
+    ink = [
+        BindingsAndFasteners(
+            overlay_types="darken",
+            foreground=img_600,
+            ntimes=1,
+            nscales=(1, 1),
+            edge="bottom",
+            edge_offset=0,
+        ),
+        Geometric(
+            scale=(0.5, 0.5),
+            rotate_range=(0, 0),
+        ),
+        PageBorder(
+            side="right",
+            noise_intensity_range=(0.5, 0.8),
+            width_range=(3, 3),
+        ),
+        Geometric(translation=(-50, 0)),
+        Letterpress(
+            n_samples=(1800, 1800),
+            n_clusters=(1800, 1800),
+            std_range=(1500, 1500),
+            value_range=(220, 240),
+            value_threshold_range=(15, 15),
+            blur=0,
+        ),
+        BindingsAndFasteners(
+            overlay_types="darken",
+            foreground=holes,
+            ntimes=1,
+            nscales=(1.5, 1.5),
+            edge="top",
+            edge_offset=10,
+        ),
+        BindingsAndFasteners(
+            overlay_types="darken",
+            foreground=p742,
+            ntimes=1,
+            nscales=(1.5, 1.5),
+            edge="bottom",
+            edge_offset=10,
+        ),
+        BadPhotoCopy(
+            noise_type=4,
+            noise_iteration=(1, 1),
+            noise_value=(0, 15),
+            noise_sparsity=(0.01, 0.01),
+            noise_concentration=(1, 1),
+        ),
+        Geometric(rotate_range=(-2, -2)),
+        LowInkRandomLines(
+            count_range=(1200, 1500),
+            use_consistent_lines=False,
+        ),
+    ]
+
+    paper = []
+    post = []
+
+    pipeline = AugraphyPipeline(ink, paper, post)
+
+    shutil.rmtree("figshare")
+
+    return pipeline.augment(clean)["output"]

--- a/augraphy/default/harley_davidson.py
+++ b/augraphy/default/harley_davidson.py
@@ -1,0 +1,51 @@
+import random
+
+import cv2
+
+from augraphy import *
+
+
+def harley_davidson(clean):
+
+    ink = [
+        Markup(
+            num_lines_range=(2, 7),
+            markup_length_range=(0.5, 1),
+            markup_thickness_range=(3, 5),
+            markup_type="strikethrough",
+            markup_color=(0, 0, 0),
+            single_word_mode=True,
+            repetitions=1,
+        ),
+        Faxify(
+            monochrome=0,
+            invert=1,
+            half_kernel_size=1,
+            angle=45,
+            sigma=2,
+        ),
+        Faxify(
+            monochrome=1,
+            monochrome_method="Otsu",
+        ),
+        BadPhotoCopy(
+            noise_type=4,
+            noise_iteration=(4, 8),
+            noise_size=(1, 4),
+            noise_sparsity=(1, 1),
+            noise_concentration=(1, 1),
+        ),
+        InkBleed(
+            intensity_range=(0.1, 0.2),
+            color_range=(0, 5),
+            kernel_size=(3, 3),
+            severity=(0.1, 0.1),
+        ),
+    ]
+
+    paper = []
+    post = []
+
+    pipeline = AugraphyPipeline(ink, paper, post)
+
+    return pipeline.augment(clean)["output"]

--- a/augraphy/default/heparin_testosterone_rats.py
+++ b/augraphy/default/heparin_testosterone_rats.py
@@ -1,0 +1,50 @@
+import random
+
+import cv2
+
+from augraphy import *
+
+
+def heparin_testosterone_rats(clean):
+    # create augmentation pipeline
+
+    ink = [
+        PageBorder(
+            side="bottom",
+            pages=40,
+            noise_intensity_range=(0.5, 0.8),
+            width_range=(30, 30),
+        ),
+        Geometric(rotate_range=(-1, -1)),
+        Geometric(crop=(0, 0, -1, 2215)),
+        Faxify(
+            monochrome=1,
+            monochrome_method="Simple",
+            monochrome_threshold=190,
+        ),
+        Letterpress(
+            n_samples=(300, 300),
+            n_clusters=(25000, 25000),
+            std_range=(80, 80),
+            value_range=(255, 255),
+            value_threshold_range=(255, 255),
+            blur=0,
+        ),
+        BadPhotoCopy(
+            noise_type=4,
+            noise_iteration=(4, 8),
+            noise_size=(1, 4),
+            noise_sparsity=(1, 1),
+            noise_concentration=(0.8, 0.9),
+        ),
+    ]
+
+    paper = []
+    post = [
+        SubtleNoise(range=1),
+        Jpeg(p=1),
+    ]
+
+    pipeline = AugraphyPipeline(ink, paper, post)
+
+    return pipeline.augment(clean)["output"]

--- a/augraphy/default/ira_jay_goldberg.py
+++ b/augraphy/default/ira_jay_goldberg.py
@@ -1,0 +1,78 @@
+import random
+
+import cv2
+import numpy as np
+
+from augraphy import *
+
+
+def ira_jay_goldberg(clean):
+    # create predefined foregrounds
+
+    # get image size
+    ysize, xsize = clean.shape[:2]
+
+    # create top and bottom black bar
+    img_black_box = np.full((200, xsize), fill_value=255).astype("uint8")
+    img_black_box[:, : xsize - 250] = 0
+
+    # create staple holes
+    img_black_line = np.full((200, xsize), fill_value=255).astype("uint8")
+    img_black_line[5:35, 275:279] = 0
+    img_black_line[55:60, 273:276] = 0
+    img_black_line[62:77, 274:277] = 0
+
+    ink1 = [
+        Faxify(
+            monochrome=1,
+            monochrome_method="Otsu",
+        ),
+        BindingsAndFasteners(
+            overlay_types="darken",
+            foreground=img_black_box,
+            ntimes=1,
+            nscales=(1, 1),
+            edge="top",
+            edge_offset=0,
+        ),
+        BindingsAndFasteners(
+            overlay_types="darken",
+            foreground=img_black_line,
+            ntimes=1,
+            nscales=(1, 1),
+            edge="top",
+            edge_offset=280,
+        ),
+        BindingsAndFasteners(
+            overlay_types="darken",
+            foreground=img_black_box,
+            ntimes=1,
+            nscales=(1, 1),
+            edge="bottom",
+            edge_offset=100,
+        ),
+        BindingsAndFasteners(
+            overlay_types="darken",
+            effect_type="punch_holes",
+            ntimes=3,
+            nscales=(1.5, 1.5),
+            edge="left",
+            edge_offset=250,
+        ),
+        InkBleed(
+            intensity_range=(0.1, 0.2),
+            color_range=(0, 5),
+            kernel_size=(3, 3),
+            severity=(0.2, 0.2),
+        ),
+    ]
+
+    paper1 = []
+    post1 = [
+        SubtleNoise(p=1),
+        Jpeg(p=1),
+    ]
+
+    pipeline = AugraphyPipeline(ink1, paper1, post1)
+
+    return pipeline.augment(clean)["output"]

--- a/augraphy/default/let_us_have_facts.py
+++ b/augraphy/default/let_us_have_facts.py
@@ -1,0 +1,156 @@
+import random
+import shutil
+
+import cv2
+import numpy as np
+
+from augraphy import *
+from augraphy.utilities.figsharedownloader import FigshareDownloader
+
+
+def let_us_have_facts(clean):
+
+    fsdl = FigshareDownloader()
+    fsdl.download_file_by_id(33912014, "binderclip.jpg")
+    fsdl.download_file_by_id(33912008, "binderring.jpg")
+    binder_clip = cv2.imread("figshare/binderclip.jpg")
+    binder_ring = cv2.imread("figshare/binderring.jpg")
+
+    ink1 = [
+        Markup(num_lines_range=(3, 3), markup_thickness_range=(2, 3), markup_color=(0, 0, 0)),
+        BindingsAndFasteners(
+            foreground=None,
+            effect_type="punch_holes",
+            ntimes=3,
+            nscales=(1, 1),
+            edge="left",
+            edge_offset=20,
+        ),
+        PageBorder(side="right", noise_intensity_range=(0.5, 0.8), width_range=(5, 10)),
+        PageBorder(side="top", noise_intensity_range=(0.5, 0.8), width_range=(5, 10)),
+        PageBorder(side="left", noise_intensity_range=(0.5, 0.8), width_range=(5, 10)),
+        Geometric(scale=(0.84, 0.85), rotate_range=(2, 2)),
+    ]
+    paper1 = []
+    post1 = []
+
+    pipeline1 = AugraphyPipeline(ink1, paper1, post1)
+    img_output1 = pipeline1.augment(clean)["output"]
+
+    # blank image to create pre-defined mask of noise
+    blank_mask = np.full((clean.shape[0], clean.shape[1]), fill_value=255).astype("uint8")
+
+    # object for badphotocopy with noise on top
+    badphotocopy1 = BadPhotoCopy(
+        noise_type=7,
+        noise_value=(0, 1),
+        noise_sparsity=(0.5, 0.5),
+        noise_concentration=(1, 1),
+    )
+
+    # dirty drum object to create horizontal direction effect
+    dirty_drum1 = DirtyDrum(
+        line_width_range=(4, 8),
+        direction=0,
+        noise_intensity=0.95,
+        ksize=(3, 3),
+        sigmaX=0,
+    )
+
+    # dirty drum object to create vertical direction effect
+    dirty_drum2 = DirtyDrum(
+        line_width_range=(100, 100),
+        direction=1,
+        noise_intensity=0.95,
+        ksize=(3, 3),
+        sigmaX=0,
+    )
+
+    # letter press object to create cluster based noise
+    letter_press1 = Letterpress(
+        n_samples=(10000, 12000),
+        n_clusters=(90, 100),
+        std_range=(12000, 15000),
+        value_range=(200, 255),
+    )
+
+    # get letter press mask and invert image
+    letter_press_mask = letter_press1(255 - blank_mask)
+
+    # get each directional mask and invert image
+    dirty_drum_mask_h = 255 - dirty_drum1(blank_mask)
+    dirty_drum_mask_v = 255 - dirty_drum2(blank_mask)
+
+    # combine vertical and horizontal direction dirty drum mask
+    dirty_drum_mask_h[dirty_drum_mask_h > 0] = 1
+    dirty_drum_mask_v[dirty_drum_mask_v > 0] = 1
+    dirty_drum_mask = dirty_drum_mask_h + dirty_drum_mask_v
+    dirty_drum_mask[dirty_drum_mask > 0] = 1
+
+    # produce cluster based noise effect
+    dirty_drum_mask[letter_press_mask > 0] = 1
+
+    # create badphotocopy mask with noise on top
+    badphotocopy_mask = 255 - badphotocopy1(blank_mask)
+
+    # create the final mask of noise
+    dirty_mask = 255 - (dirty_drum_mask * badphotocopy_mask)
+
+    ink2 = [
+        BindingsAndFasteners(
+            foreground=img_output1,
+            overlay_types="darken",
+            ntimes=1,
+            nscales=(1, 1),
+            edge="top",
+            edge_offset=600,
+        ),
+        BindingsAndFasteners(
+            foreground=binder_clip,
+            overlay_types="darken",
+            ntimes=3,
+            nscales=(2, 2),
+            edge="bottom",
+            edge_offset=30,
+        ),
+        BindingsAndFasteners(
+            foreground=binder_ring,
+            overlay_types="darken",
+            ntimes=3,
+            nscales=(2, 2),
+            edge="right",
+            edge_offset=10,
+        ),
+        Letterpress(
+            n_samples=(400, 500),
+            n_clusters=(500, 1000),
+            std_range=(500, 500),
+            value_range=(200, 255),
+        ),
+        BadPhotoCopy(
+            noise_type=4,
+            noise_value=(0, 15),
+            noise_sparsity=(0.01, 0.01),
+            noise_concentration=(1, 1),
+        ),
+        BadPhotoCopy(mask=dirty_mask, noise_type=7),
+        BadPhotoCopy(
+            noise_type=7,
+            noise_value=(0, 5),
+            noise_sparsity=(0.001, 0.001),
+            noise_concentration=(1, 1),
+        ),
+    ]
+
+    paper2 = []
+    post2 = []
+
+    # create a blank image
+    img_blank = np.full_like(clean, fill_value=255)
+
+    # apply pipeline
+    pipeline2 = AugraphyPipeline(ink2, paper2, post2)
+
+    shutil.rmtree("figshare")
+
+    return pipeline2.augment(img_blank)["output"]

--- a/augraphy/default/lorillard.py
+++ b/augraphy/default/lorillard.py
@@ -1,0 +1,178 @@
+import random
+
+import cv2
+import numpy as np
+
+from augraphy import *
+
+
+def lorillard(clean):
+    # create noise mask, subject to change later
+
+    ysize, xsize = clean.shape[:2]
+
+    # blank image, each to create different kind of noise masks
+    blank_mask = np.full((int(clean.shape[0]), int(clean.shape[1])), fill_value=255).astype("uint8")
+    blank_mask11 = np.full((int(clean.shape[0] / 8), int(clean.shape[1] / 8)), fill_value=255).astype("uint8")
+    blank_mask12 = np.full((int(clean.shape[0] / 4), int(clean.shape[1] / 4)), fill_value=255).astype("uint8")
+    blank_mask13 = np.full((int(clean.shape[0] / 2), int(clean.shape[1] / 2)), fill_value=255).astype("uint8")
+    blank_mask2 = np.full((int(clean.shape[0] / 8), int(clean.shape[1] / 8)), fill_value=255).astype("uint8")
+    blank_mask3 = np.full((int(clean.shape[0] / 8), int(clean.shape[1] / 8)), fill_value=255).astype("uint8")
+
+    # create object for each noise effect
+    badphotocopy11 = BadPhotoCopy(
+        noise_type=6,
+        noise_value=(0, 0),
+        noise_sparsity=(0.4, 0.4),
+        noise_concentration=(0.5, 0.5),
+    )
+
+    badphotocopy12 = BadPhotoCopy(
+        noise_type=6,
+        noise_value=(0, 0),
+        noise_sparsity=(0.3, 0.3),
+        noise_concentration=(0.5, 0.5),
+    )
+
+    badphotocopy13 = BadPhotoCopy(
+        noise_type=6,
+        noise_value=(0, 0),
+        noise_sparsity=(0.2, 0.2),
+        noise_concentration=(0.5, 0.5),
+    )
+
+    badphotocopy2 = BadPhotoCopy(
+        noise_type=5,
+        noise_value=(0, 0),
+        noise_sparsity=(0.1, 0.1),
+        noise_concentration=(0.1, 0.1),
+    )
+
+    badphotocopy3 = BadPhotoCopy(
+        noise_type=6,
+        noise_value=(0, 0),
+        noise_sparsity=(0.1, 0.1),
+        noise_concentration=(0.15, 0.15),
+    )
+
+    # get noise mask
+    badphotocopy_mask11 = 255 - badphotocopy11(blank_mask11)
+    badphotocopy_mask12 = 255 - badphotocopy11(blank_mask12)
+    badphotocopy_mask13 = 255 - badphotocopy11(blank_mask13)
+    badphotocopy_mask2 = 255 - badphotocopy2(blank_mask2)
+    badphotocopy_mask3 = 255 - badphotocopy3(blank_mask3)
+
+    # resize each noise mask back to input size
+    badphotocopy_mask11 = resized = cv2.resize(badphotocopy_mask11, (xsize, ysize), interpolation=cv2.INTER_AREA)
+    badphotocopy_mask12 = resized = cv2.resize(badphotocopy_mask12, (xsize, ysize), interpolation=cv2.INTER_AREA)
+    badphotocopy_mask13 = resized = cv2.resize(badphotocopy_mask13, (xsize, ysize), interpolation=cv2.INTER_AREA)
+    badphotocopy_mask2 = resized = cv2.resize(badphotocopy_mask2, (xsize, ysize), interpolation=cv2.INTER_AREA)
+    badphotocopy_mask3 = resized = cv2.resize(badphotocopy_mask3, (xsize, ysize), interpolation=cv2.INTER_AREA)
+
+    # combined all noise mask
+    badphotocopy_mask = badphotocopy_mask11 + badphotocopy_mask12 + badphotocopy_mask13 + badphotocopy_mask2
+
+    # create dirty drum noise mask object
+    dirty_drum1 = DirtyDrum(
+        line_width_range=(18, 18),
+        direction=1,
+        noise_intensity=0.95,
+        ksize=(3, 3),
+        sigmaX=0,
+    )
+
+    # create letterpress noise mask object
+    letter_press1 = Letterpress(
+        n_samples=(5000, 6000),
+        n_clusters=(120, 120),
+        std_range=(12000, 15000),
+        value_range=(255, 255),
+    )
+
+    # create letterpress noise mask
+    letter_press_mask = letter_press1(255 - blank_mask)
+
+    # create letterpress noise mask
+    dirty_drum_mask = 255 - dirty_drum1(blank_mask)
+    dirty_drum_mask[dirty_drum_mask > 0] = 1
+    dirty_drum_mask[letter_press_mask < 5] = 0
+    dirty_drum_mask[letter_press_mask > 5] = 1
+
+    # combine letterpress, dirty and badphotocopy noise mask
+    dirty_mask = (255 - (dirty_drum_mask * badphotocopy_mask)).astype("int")
+    dirty_mask = 255 - ((255 - dirty_mask) + badphotocopy_mask3)
+    dirty_mask -= 200
+    dirty_mask[dirty_mask < 0] = 0
+    dirty_mask = dirty_mask.astype("uint8")
+
+    # pipeline 1
+
+    ink1 = [
+        Faxify(
+            monochrome=1,
+            monochrome_method="Otsu",
+        ),
+        PageBorder(side="bottom", noise_intensity_range=(0.5, 0.8), width_range=(4, 5)),
+        # PageBorder(side="right", noise_intensity_range=(0.5 , 0.8),width_range=(4,5)),
+        BadPhotoCopy(mask=dirty_mask, noise_type=5),
+        InkBleed(
+            intensity_range=(0.1, 0.2),
+            color_range=(0, 5),
+            kernel_size=(3, 3),
+            severity=(0.4, 0.5),
+        ),
+        Geometric(rotate_range=(-3, -3)),
+    ]
+
+    paper1 = []
+    post1 = [
+        SubtleNoise(p=1),
+        Jpeg(p=1),
+    ]
+
+    # create pipeline 1 and applies augmentation
+    pipeline1 = AugraphyPipeline(ink1, paper1, post1)
+    img_output1 = pipeline1.augment(clean)["output"]
+
+    # pipeline 2
+
+    img_blank = np.full_like(img_output1, fill_value=255).astype("uint8")
+
+    ink2 = [
+        BindingsAndFasteners(
+            foreground=img_output1,
+            overlay_types="darken",
+            ntimes=1,
+            nscales=(1, 1),
+            edge="bottom",
+            edge_offset=150,
+        ),
+        BindingsAndFasteners(
+            overlay_types="darken",
+            effect_type="clips",
+            ntimes=2,
+            nscales=(8, 8),
+            edge="bottom",
+            edge_offset=40,
+        ),
+        PageBorder(
+            side="left",
+            width_range=(6, 7),
+            pages=5,
+            noise_intensity_range=(0.0, 0.2),
+        ),
+        PageBorder(
+            side="bottom",
+            width_range=(8, 12),
+            pages=5,
+            noise_intensity_range=(0.0, 0.2),
+        ),
+    ]
+
+    paper2 = []
+    post2 = []
+
+    # create pipeline 2 and applies augmentation
+    pipeline2 = AugraphyPipeline(ink2, paper2, post2)
+
+    return pipeline2.augment(img_blank)["output"]

--- a/augraphy/default/marlboro_500.py
+++ b/augraphy/default/marlboro_500.py
@@ -1,0 +1,55 @@
+import random
+
+import cv2
+import numpy as np
+
+from augraphy import *
+
+
+def marlboro_500(clean):
+    # manual cropping and add noise
+
+    # clean[250:, :] = clean[:-250, :]
+    # clean[:250, :] = 255
+    # clean[2150, 1400:1555] = 0
+
+    # create augmentation pipeline
+
+    ink = [
+        Geometric(scale=(2, 2)),
+        Faxify(
+            monochrome=0,
+            invert=1,
+            half_kernel_size=1,
+            angle=35,
+            sigma=2,
+        ),
+        Geometric(scale=(0.5, 0.5)),
+        Faxify(
+            monochrome=1,
+            monochrome_method="Adaptive",
+            adaptive_method=cv2.ADAPTIVE_THRESH_MEAN_C,
+        ),
+        BadPhotoCopy(
+            noise_type=4,
+            noise_iteration=(4, 8),
+            noise_size=(1, 4),
+            noise_sparsity=(1, 1),
+            noise_concentration=(0.5, 0.8),
+        ),
+        Letterpress(
+            n_samples=(2800, 2800),
+            n_clusters=(600, 680),
+            std_range=(1500, 1500),
+            value_range=(245, 255),
+            value_threshold_range=(128, 128),
+            blur=0,
+        ),
+    ]
+
+    paper = []
+    post = []
+
+    pipeline = AugraphyPipeline(ink, paper, post)
+
+    return pipeline.augment(clean)["output"]

--- a/augraphy/default/philip_morris.py
+++ b/augraphy/default/philip_morris.py
@@ -1,0 +1,46 @@
+import random
+
+import cv2
+
+from augraphy import *
+
+
+def philip_morris(clean):
+    ink = [
+        Faxify(
+            monochrome=1,
+            monochrome_method="Otsu",
+        ),
+        InkBleed(
+            intensity_range=(0.9, 0.9),
+            color_range=(0, 0),
+            kernel_size=(3, 3),
+            severity=(0.9, 0.9),
+        ),
+        BadPhotoCopy(
+            noise_type=3,
+            noise_iteration=(5, 8),
+            noise_size=(1, 4),
+            noise_sparsity=(0.025, 0.025),
+            noise_concentration=(0.025, 0.025),
+        ),
+        BadPhotoCopy(
+            noise_type=4,
+            noise_iteration=(4, 8),
+            noise_size=(1, 4),
+            noise_sparsity=(1, 1),
+            noise_concentration=(0.5, 0.8),
+        ),
+        InkBleed(
+            intensity_range=(0.1, 0.2),
+            color_range=(0, 0),
+            kernel_size=(3, 3),
+            severity=(0.9, 0.9),
+        ),
+    ]
+    paper = []
+    post = []
+
+    pipeline = AugraphyPipeline(ink, paper, post)
+
+    return pipeline.augment(clean)["output"]

--- a/augraphy/default/statesmans_manual.py
+++ b/augraphy/default/statesmans_manual.py
@@ -1,0 +1,69 @@
+import random
+
+import cv2
+import numpy as np
+
+from augraphy import *
+
+
+def statesmans_manual(clean):
+    # create mask of noise
+
+    blank_image = np.full_like(clean, fill_value=255).astype("uint8")
+
+    # object for badphotocopy effect 1
+    badphotocopy1 = BadPhotoCopy(
+        noise_type=3,
+        noise_value=(50, 70),
+        noise_sparsity=(0.05, 0.05),
+        noise_concentration=(0.1, 0.1),
+        blur_noise=1,
+        blur_noise_kernel=(31, 31),
+    )
+
+    # object for badphotocopy effect 2
+    badphotocopy2 = BadPhotoCopy(
+        noise_type=3,
+        noise_value=(150, 160),
+        noise_sparsity=(0.4, 0.4),
+        noise_concentration=(0.3, 0.3),
+        blur_noise=1,
+        blur_noise_kernel=(31, 31),
+    )
+
+    noise_mask1 = badphotocopy1(blank_image)
+    noise_mask2 = badphotocopy2(blank_image)
+
+    # stack both masks by using min of both masks
+    noise_mask1[noise_mask1 > noise_mask2] = noise_mask2[noise_mask1 > noise_mask2]
+
+    # create augmenation pipeline
+
+    ink = [
+        BadPhotoCopy(mask=noise_mask1, blur_noise=1, blur_noise_kernel=(31, 31)),
+        InkBleed(
+            intensity_range=(0.1, 0.2),
+            color_range=(0, 5),
+            kernel_size=(3, 3),
+            severity=(0.1, 0.2),
+        ),
+        BleedThrough(
+            intensity_range=(0.1, 0.2),
+            color_range=(0, 224),
+            ksize=(17, 17),
+            sigmaX=0,
+            alpha=0.3,
+            offsets=(10, 20),
+        ),
+        Geometric(scale=(1, 1), rotate_range=(2, 2)),
+    ]
+
+    paper = []
+    post = [
+        SubtleNoise(p=1),
+        Jpeg(p=1),
+    ]
+
+    pipeline = AugraphyPipeline(ink, paper, post)
+
+    return pipeline.augment(clean)["output"]

--- a/doc/default/aktives-und-passives-rauchen.md
+++ b/doc/default/aktives-und-passives-rauchen.md
@@ -1,0 +1,5 @@
+# Book - Aktives Und Passives Rauchen - 1985
+
+This pipeline reproduces [this image]().
+
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)]()

--- a/doc/default/default-pipeline.md
+++ b/doc/default/default-pipeline.md
@@ -1,0 +1,3 @@
+# Default Pipeline
+
+This is the default Augraphy pipeline, which contains every augmentation in the project.

--- a/doc/default/diahann-carroll.md
+++ b/doc/default/diahann-carroll.md
@@ -1,0 +1,5 @@
+# Letter - Diahann Carroll - 1972
+
+This pipeline reproduces [this image]().
+
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)]()

--- a/doc/default/harley-davidson.md
+++ b/doc/default/harley-davidson.md
@@ -1,0 +1,5 @@
+# Form - Fax - Harley-Davidson Cigarettes Report - 1994
+
+This pipeline reproduces [this image]().
+
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)]()

--- a/doc/default/heparin-testosterone-rats.md
+++ b/doc/default/heparin-testosterone-rats.md
@@ -1,0 +1,5 @@
+# Article - Heparin Testosterone Rats - 1976
+
+This pipeline reproduces [this image]().
+
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)]()

--- a/doc/default/ira-jay-goldberg.md
+++ b/doc/default/ira-jay-goldberg.md
@@ -1,0 +1,5 @@
+# Resume - Ira Jay Goldberg - 1986
+
+This pipeline reproduces [this image]().
+
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)]()

--- a/doc/default/let-us-have-facts.md
+++ b/doc/default/let-us-have-facts.md
@@ -1,0 +1,5 @@
+# News - Let Us Have Facts - 1962
+
+This pipeline reproduces [this image]().
+
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)]()

--- a/doc/default/lorillard.md
+++ b/doc/default/lorillard.md
@@ -1,0 +1,5 @@
+# Memo - Lorillard TCRC Analytical Methods
+
+This pipeline reproduces [this image]().
+
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)]()

--- a/doc/default/marlboro-500.md
+++ b/doc/default/marlboro-500.md
@@ -1,0 +1,5 @@
+# News - Marlboro 500 - 1993
+
+This pipeline reproduces [this image]().
+
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)]()

--- a/doc/default/philip-morris.md
+++ b/doc/default/philip-morris.md
@@ -1,0 +1,5 @@
+# Form - Philip Morris - End of File - 1994
+
+This pipeline reproduces [this image]().
+
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)]()

--- a/doc/default/statesmans-manual.md
+++ b/doc/default/statesmans-manual.md
@@ -1,0 +1,5 @@
+# Book - Statesman's Manual - 1823
+
+This pipeline reproduces [this image]().
+
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)]()

--- a/tests/aktives_und_passives_rauchen_test.py
+++ b/tests/aktives_und_passives_rauchen_test.py
@@ -1,0 +1,7 @@
+import pytest
+
+from augraphy import *
+
+
+def test_aktives_und_passives_rauchen(random_image):
+    augmented = aktives_und_passives_rauchen(random_image)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,11 @@
+import random
+
+import numpy as np
+import pytest
+
+
+@pytest.fixture
+def random_image():
+    xdim = random.randint(30, 500)
+    ydim = random.randint(30, 500)
+    return np.random.randint(low=0, high=255, size=(xdim, ydim, 3), dtype=np.uint8)

--- a/tests/default_pipeline_test.py
+++ b/tests/default_pipeline_test.py
@@ -1,22 +1,7 @@
-import random
-
-import numpy as np
 import pytest
 
 from augraphy import *
 
 
-@pytest.fixture
-def random_image():
-    xdim = random.randint(30, 500)
-    ydim = random.randint(30, 500)
-    return np.random.randint(low=0, high=255, size=(xdim, ydim, 3), dtype=np.uint8)
-
-
-@pytest.fixture
-def default_pipeline():
-    return default_augraphy_pipeline()
-
-
-def test_default_pipeline(random_image, default_pipeline):
-    augmented = default_pipeline.augment(random_image)
+def test_default_pipeline(random_image):
+    augmented = default_augraphy_pipeline(random_image)

--- a/tests/diahann_carroll_test.py
+++ b/tests/diahann_carroll_test.py
@@ -1,0 +1,7 @@
+import pytest
+
+from augraphy import *
+
+
+def test_diahann_carroll(random_image):
+    augmented = diahann_carroll(random_image)

--- a/tests/harley_davidson_test.py
+++ b/tests/harley_davidson_test.py
@@ -1,0 +1,7 @@
+import pytest
+
+from augraphy import *
+
+
+def test_harley_davidson(random_image):
+    augmented = harley_davidson(random_image)

--- a/tests/heparin_testosterone_rats_test.py
+++ b/tests/heparin_testosterone_rats_test.py
@@ -1,0 +1,7 @@
+import pytest
+
+from augraphy import *
+
+
+def test_heparin_testosterone_rats(random_image):
+    augmented = heparin_testosterone_rats(random_image)

--- a/tests/ira_jay_goldberg_test.py
+++ b/tests/ira_jay_goldberg_test.py
@@ -1,0 +1,7 @@
+import pytest
+
+from augraphy import *
+
+
+def test_ira_jay_goldberg(random_image):
+    augmented = ira_jay_goldberg(random_image)

--- a/tests/let_us_have_facts_test.py
+++ b/tests/let_us_have_facts_test.py
@@ -1,0 +1,7 @@
+import pytest
+
+from augraphy import *
+
+
+def test_let_us_have_facts(random_image):
+    augmented = let_us_have_facts(random_image)

--- a/tests/lorillard_test.py
+++ b/tests/lorillard_test.py
@@ -1,0 +1,7 @@
+import pytest
+
+from augraphy import *
+
+
+def test_lorillard(random_image):
+    augmented = lorillard(random_image)

--- a/tests/marlboro_500_test.py
+++ b/tests/marlboro_500_test.py
@@ -1,0 +1,7 @@
+import pytest
+
+from augraphy import *
+
+
+def test_marlboro_500(random_image):
+    augmented = marlboro_500(random_image)

--- a/tests/philip_morris_test.py
+++ b/tests/philip_morris_test.py
@@ -1,0 +1,7 @@
+import pytest
+
+from augraphy import *
+
+
+def test_philip_morris(random_image):
+    augmented = philip_morris(random_image)

--- a/tests/statesmans_manual_test.py
+++ b/tests/statesmans_manual_test.py
@@ -1,0 +1,7 @@
+import pytest
+
+from augraphy import *
+
+
+def test_statesmans_manual(random_image):
+    augmented = statesmans_manual(random_image)


### PR DESCRIPTION
This PR:

- adds the archetype pipelines mentioned in #150 to `augraphy.default`
- adds more tests to run those pipelines against random images
- makes pipelines return augmented images directly