### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setuptools.setup(
     install_requires=[
         "numpy >= 1.20.1",
         "opencv-python >= 4.5.1.48",
-        "sklearn >= 0.0",
+        "scikit-learn >= 0.0",
         "scipy >= 1.6.3",
     ],
 )


### PR DESCRIPTION
Related to https://github.com/sparkfish/augraphy/issues/210.

I was still not able to install `augraphy` using `pip install git+https://github.com/sparkfish/augraphy`. Since 1st December, using the name `sklearn` is deprecated and the build can fail (cf https://pypi.org/project/sklearn/).

This PR should solve this issue.