### PR TITLE
Remove `random.*` from `__init__` kwargs

### DIFF
--- a/augraphy/augmentations/bookbinding.py
+++ b/augraphy/augmentations/bookbinding.py
@@ -30,7 +30,7 @@ class BookBinding(Augmentation):
         radius_range=(1, 100),
         curve_range=(200, 300),
         mirror_range=(0.2, 0.5),
-        curling_direction=random.choice([0, 1]),
+        curling_direction=0,
         p=1,
     ):
         super().__init__(p=p)

--- a/augraphy/augmentations/dirtydrum.py
+++ b/augraphy/augmentations/dirtydrum.py
@@ -38,7 +38,7 @@ class DirtyDrum(Augmentation):
         self,
         line_width_range=(1, 4),
         line_concentration=0.1,
-        direction=random.randint(0, 2),
+        direction=0,
         noise_intensity=0.5,
         noise_value=(0, 30),
         ksize=(3, 3),


### PR DESCRIPTION
Hi,

I saw a reproducibility using `DirtyDrum` augmentation. This is due to `direction` kwarg which is initialized by `random.randint`. So,  by using `DirtyDrum` with default params and setting a seed, I don't get the same result.

Here is a snippet to reproduce this issue:
```python
import cv2
import random
import numpy as np
from augraphy import *

my_random_seed = 42

random.seed(my_random_seed)
np.random.seed(my_random_seed)
cv2.setRNGSeed(my_random_seed)

# create a clean image with single line of text
image = np.full((500, 1500, 3), 250, dtype="uint8")
cv2.putText(
    image,
    "Lorem ipsum dolor sit amet, consectetur adipiscing elit",
    (80, 250),
    cv2.FONT_HERSHEY_SIMPLEX,
    1.5,
    0,
    3,
)

dirtydrum = DirtyDrum()
img_dirtydrum = dirtydrum(image)
cv2.imshow("dirtydrum", img_dirtydrum)
key = cv2.waitKey(0)
if key == 27: # Escape key
    cv2.destroyAllWindows()
```

I also spotted the same issue in another augmentation. I suggest to remove `random.*` from `__init__` kwargs to avoid these kind of reproducibility issue.