### PR TITLE
add support for python 3.11, remove support for 3.7

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
   main:
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
 
     runs-on: ubuntu-latest
     steps:

--- a/setup.py
+++ b/setup.py
@@ -26,10 +26,10 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     packages=setuptools.find_packages(),
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     install_requires=[
         "matplotlib >= 3.4.3",
-        "numba >= 0.54.1",
+        "numba >= 0.57.0",
         "numpy >= 1.20.1",
         "opencv-python >= 4.5.1.48",
         "Pillow >= 8.0.0",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37, py38, py39, py310, pre-commit
+envlist = py38, py39, py310, py311, pre-commit
 
 [testenv]
 # install dependencies in the virtualenv where commands will be executed


### PR DESCRIPTION
This closes #273.

[Python 3.11 is now supported in Numba](https://numba.readthedocs.io/en/0.57.1/release-notes.html#version-0-57-0-1-may-2023).