### PR TITLE
Fix UnboundLocalError in Geometric

### DIFF
--- a/augraphy/augmentations/geometric.py
+++ b/augraphy/augmentations/geometric.py
@@ -187,6 +187,7 @@ class Geometric(Augmentation):
                 # remove and limit bounding boxes to the cropped boundary
                 if bounding_boxes is not None:
                     # check each point, and remove them if it is outside the cropping area
+                    remove_indices = []
                     for i, bounding_box in enumerate(bounding_boxes):
                         xspoint, yspoint, xepoint, yepoint = bounding_box
                         # start point is outside the croped area, but end point is inside


### PR DESCRIPTION
When I tried to use the `Geometric` augmentation with bounding boxes but without key-points, I got an `UnboundLocalError` due to the `remove_indices `-list not existing at line 212. This PR should hopefully fix that.