### PR TITLE
Update some augmentations to work with new version of numpy

### DIFF
--- a/augraphy/augmentations/badphotocopy.py
+++ b/augraphy/augmentations/badphotocopy.py
@@ -88,18 +88,18 @@ class BadPhotoCopy(Augmentation):
         # clamp values
         # noise value range from 0-255
         self.noise_value = list(self.noise_value)
-        self.noise_value[0] = np.clip(self.noise_value[0], 0, 255)
-        self.noise_value[1] = np.clip(self.noise_value[1], 0, 255)
+        self.noise_value[0] = np.clip(self.noise_value[0], 0, 255).item()
+        self.noise_value[1] = np.clip(self.noise_value[1], 0, 255).item()
 
         # sparsity range from 0-1
         self.noise_sparsity = list(self.noise_sparsity)
-        self.noise_sparsity[0] = np.clip(self.noise_sparsity[0], 0, 1)
-        self.noise_sparsity[1] = np.clip(self.noise_sparsity[1], 0, 1)
+        self.noise_sparsity[0] = np.clip(self.noise_sparsity[0], 0, 1).item()
+        self.noise_sparsity[1] = np.clip(self.noise_sparsity[1], 0, 1).item()
 
         # concentration range from 0-1
         self.noise_concentration = list(self.noise_concentration)
-        self.noise_concentration[0] = np.clip(self.noise_concentration[0], 0, 1)
-        self.noise_concentration[1] = np.clip(self.noise_concentration[1], 0, 1)
+        self.noise_concentration[0] = np.clip(self.noise_concentration[0], 0, 1).item()
+        self.noise_concentration[1] = np.clip(self.noise_concentration[1], 0, 1).item()
 
     # Constructs a string representation of this Augmentation.
     def __repr__(self):

--- a/augraphy/utilities/inkgenerator.py
+++ b/augraphy/utilities/inkgenerator.py
@@ -346,7 +346,7 @@ class InkGenerator:
 
         n_clusters = (200 + kernel_size * 10, 250 + kernel_size * 10)
         n_samples = (200 + kernel_size * 5, 250 + kernel_size * 5)
-        std_range = (3 + np.ceil(kernel_size / 5).astype(int), 7 + np.ceil(kernel_size / 5).astype(int))
+        std_range = (3 + np.ceil(kernel_size / 5).item(), 7 + np.ceil(kernel_size / 5).item())
         image_noise_center = self.generate_noise_clusters(gray_image, n_clusters, n_samples, std_range)
         image_noise_border = self.generate_noise_clusters(gray_image, n_clusters, n_samples, std_range)
 

--- a/augraphy/utilities/inkgenerator.py
+++ b/augraphy/utilities/inkgenerator.py
@@ -346,7 +346,7 @@ class InkGenerator:
 
         n_clusters = (200 + kernel_size * 10, 250 + kernel_size * 10)
         n_samples = (200 + kernel_size * 5, 250 + kernel_size * 5)
-        std_range = (3 + np.ceil(kernel_size / 5).item(), 7 + np.ceil(kernel_size / 5).item())
+        std_range = (3 + np.ceil(kernel_size / 5).astype(int), 7 + np.ceil(kernel_size / 5).astype(int))
         image_noise_center = self.generate_noise_clusters(gray_image, n_clusters, n_samples, std_range)
         image_noise_border = self.generate_noise_clusters(gray_image, n_clusters, n_samples, std_range)
 

--- a/augraphy/utilities/inkgenerator.py
+++ b/augraphy/utilities/inkgenerator.py
@@ -346,7 +346,7 @@ class InkGenerator:
 
         n_clusters = (200 + kernel_size * 10, 250 + kernel_size * 10)
         n_samples = (200 + kernel_size * 5, 250 + kernel_size * 5)
-        std_range = (3 + np.ceil(kernel_size / 5), 7 + np.ceil(kernel_size / 5))
+        std_range = (3 + np.ceil(kernel_size / 5).astype(int), 7 + np.ceil(kernel_size / 5).astype(int))
         image_noise_center = self.generate_noise_clusters(gray_image, n_clusters, n_samples, std_range)
         image_noise_border = self.generate_noise_clusters(gray_image, n_clusters, n_samples, std_range)
 


### PR DESCRIPTION
I got errors when I tried to use the highlighter effect. It turned out that the std_range was integers but stored as floating point numbers. `random.randint` needs integers, so by explicitly casting to `int`, the code works again.