### PR TITLE
fix OneOf and AugmentationsSequence to process bboxes properly

### DIFF
--- a/augraphy/base/augmentationpipeline.py
+++ b/augraphy/base/augmentationpipeline.py
@@ -11,6 +11,7 @@ import numpy as np
 from augraphy.base.augmentation import Augmentation
 from augraphy.base.augmentationresult import AugmentationResult
 from augraphy.base.augmentationsequence import AugmentationSequence
+from augraphy.base.oneof import OneOf
 from augraphy.utilities.detectdpi import dpi_resize
 from augraphy.utilities.detectdpi import DPIMetrics
 from augraphy.utilities.overlaybuilder import OverlayBuilder
@@ -750,7 +751,9 @@ class AugraphyPipeline:
                 data["log"]["time"].append((augmentation, elapsed))
 
                 # not "OneOf" or "AugmentationSequence"
-                if isinstance(augmentation, Augmentation):
+                if isinstance(augmentation, Augmentation) \
+                    and not isinstance(augmentation, AugmentationSequence) \
+                    and not isinstance(augmentation, OneOf):
                     # unpacking augmented image, mask, keypoints and bounding boxes from output
                     if (mask is not None) or (keypoints is not None) or (bounding_boxes is not None):
                         result, mask, keypoints, bounding_boxes = result

--- a/augraphy/base/augmentationsequence.py
+++ b/augraphy/base/augmentationsequence.py
@@ -48,5 +48,5 @@ class AugmentationSequence(Augmentation):
                 elif isinstance(current_result, tuple):
                     if current_result[0] is not None:
                         result = current_result
-
+            result = (result, mask, keypoints, bounding_boxes)
             return result, self.augmentations

--- a/augraphy/base/oneof.py
+++ b/augraphy/base/oneof.py
@@ -29,8 +29,10 @@ class OneOf(Augmentation):
             augmentation = self.augmentations[np.argmax(self.augmentation_probabilities)]
 
             # Applies the selected Augmentation.
-            image = augmentation(image, mask=mask, keypoints=keypoints, bounding_boxes=bounding_boxes, force=True)
-            return image, [augmentation]
+            result = augmentation(image, mask=mask, keypoints=keypoints, bounding_boxes=bounding_boxes, force=True)
+            if isinstance(augmentation, AugmentationSequence):
+                return result[0], result[1]
+            return result, [augmentation]
 
     # Constructs a string containing the representations
     # of each augmentation


### PR DESCRIPTION
As mentioned in #445, bounding boxes, keypoints and mask is not processed properly when `OneOf` or `AugmentationSequence` is used. The following issues is fixed:
- Fix `augraphy/base/augmentationpipeline.py:753`. The line do not filter `OneOf` or `AugmentationSequence` because these classes are children of 'Augmentation' class.
- Make `AugmentationSequence` return bboxes and other info inside result variable.
- In case when `AugmentationSequence` is inside `OneOf` object I added to `OneOf` some code to return bboxes and other info accurately.