### PR TITLE
fix: DepthSimulatedBlur augmentation typo

### DIFF
--- a/augraphy/augmentations/depthsimulatedblur.py
+++ b/augraphy/augmentations/depthsimulatedblur.py
@@ -9,7 +9,7 @@ from augraphy.base.augmentation import Augmentation
 class DepthSimulatedBlur(Augmentation):
     """Creates a depth-simulated blur effect from a camera by blurring a small elliptical region of image.
 
-    :param blur_centerr: Center (x,y) of blur effect. Use "random" for random location.
+    :param blur_center: Center (x,y) of blur effect. Use "random" for random location.
     :type blur_center: tuple or string, optional
     :param blur_major_axes_length_range: Pair of ints determining the value of major axis in the blurring ellipse.
     :type blur_major_axes_length_range: tuple, optional


### PR DESCRIPTION
On [augraphy 8.2.0 documentation](https://augraphy.readthedocs.io/en/latest/index.html), 

DepthSimulatedBlur first parameter has a typo, fixing from 

blur_centerr -> blur_center

<img width="776" height="381" alt="Screenshot 2025-08-06 at 20 29 33" src="https://github.com/user-attachments/assets/31d3ca3f-8df4-4671-8723-1eb438185a02" />
