### PR TITLE
Fix Example 1 documentation: pipeline() returns numpy array, not dict

### DIFF
--- a/doc/source/example_usage.rst
+++ b/doc/source/example_usage.rst
@@ -16,7 +16,11 @@ To use the default pipeline which contains all available augmentations and sensi
 
     image = cv2.imread("image.png")
 
-    data = pipeline(image)
+    # 1. Returns numpy array directly
+    augmented = pipeline(image)
+
+    # 2. Explicitly request dictionary
+    data = pipeline.augment(image, return_dict=1)
 
     augmented = data["output"]
 


### PR DESCRIPTION
Example 1 in the documentation (https://augraphy.readthedocs.io/en/latest/doc/source/example_usage.html) contains incorrect code that causes an `IndexError` when users try to run it.
The current code shows:

```
data = pipeline(image)
augmented = data["output"]  # This causes IndexError!
```
ruturns:
```
IndexError: only integers, slices (`:`), ellipsis (`...`), numpy.newaxis (`None`) and integer or boolean arrays are valid indices
```

But pipeline(image) returns a numpy array directly (via` __call__` method which calls `augment(image, return_dict=0))`, not a dictionary.

- Solution

1. Fixed the example to use the return value correctly:
```
augmented = pipeline(image)  # Returns numpy array directly
```

2. Explicitly request dictionary:

```
data = pipeline.augment(image, return_dict=1)
augmented = data["output"]
```

- Technical Details

In `AugraphyPipeline.__call__`:
```
def __call__(self, image):
    return self.augment(image, return_dict=0)  # return_dict=0 returns numpy array
```
When `return_dict=0`, the augment method returns `data["output"]` (numpy array), not the full dictionary.